### PR TITLE
[Feat] don't do SrcExpl_Refresh when in __Tag_List__ buffer

### DIFF
--- a/plugin/srcexpl.vim
+++ b/plugin/srcexpl.vim
@@ -524,6 +524,10 @@ function! <SID>SrcExpl_Refresh()
         return -4
     endif
 
+	if bufname("%") == "__Tag_List__"
+			return -5
+	endif
+
     let l:expr = '\<' . s:SrcExpl_symbol . '\>' . '\C'
 
     " Try to Go to local declaration


### PR DESCRIPTION
Test case: when do string search in __Tag_List__, it disturbs search result jumping.

Signed-off-by: Karl.Zheng <Karl.Zheng@anker.com>